### PR TITLE
Refactor to avoid using UserStore for authentication

### DIFF
--- a/docs/user/authentication-settings-guide.md
+++ b/docs/user/authentication-settings-guide.md
@@ -14,7 +14,7 @@ JAAS Authenticator will use JAAS login modules.
         className: io.ballerina.messaging.broker.auth.authentication.authenticator.JaasAuthenticator
         # Optional properties
         properties:
-         loginModule: io.ballerina.messaging.broker.auth.authentication.jaas.UserStoreLoginModule
+         loginModule: io.ballerina.messaging.broker.auth.authentication.jaas.FileBasedJaasLoginModule
 
 
 ## Available authenticators
@@ -26,7 +26,7 @@ There are two authenticator implementations available out of the box.
 
 2) io.ballerina.messaging.broker.auth.authentication.authenticator.JaasAuthenticator
     - Provide authentication using JaaS login module. 
-    - The io.ballerina.messaging.broker.auth.authentication.jaas.UserStoreLoginModule implements 
+    - The io.ballerina.messaging.broker.auth.authentication.jaas.FileBasedJaasLoginModule implements
     the javax.security.auth.spi.LoginModule and set as a property.
 
 

--- a/docs/user/embedding-message-broker.md
+++ b/docs/user/embedding-message-broker.md
@@ -68,7 +68,7 @@ import io.ballerina.messaging.broker.EmbeddedBrokerConfiguration;
 import io.ballerina.messaging.broker.auth.BrokerAuthConstants;
 import io.ballerina.messaging.broker.auth.authentication.Authenticator;
 import io.ballerina.messaging.broker.auth.authentication.authenticator.JaasAuthenticator;
-import io.ballerina.messaging.broker.auth.authentication.jaas.UserStoreLoginModule;
+import io.ballerina.messaging.broker.auth.authentication.jaas.FileBasedJaasLoginModule;
 
 import java.util.HashMap;
 

--- a/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/AuthInitException.java
+++ b/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/AuthInitException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package io.ballerina.messaging.broker.auth;
+
+/**
+ * This Exception class represents initialization errors in Auth module.
+ */
+public class AuthInitException extends Exception {
+
+    public AuthInitException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/AuthManager.java
+++ b/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/AuthManager.java
@@ -81,8 +81,7 @@ public class AuthManager {
             UserStore userStore = AuthorizerFactory.createUserStore(startupContext, brokerAuthConfiguration);
 
             authenticator = new AuthenticatorFactory().getAuthenticator(startupContext,
-                                                                        brokerAuthConfiguration.getAuthentication(),
-                                                                        userStore);
+                                                                        brokerAuthConfiguration.getAuthentication());
 
             BrokerCommonConfiguration commonConfigs
                     = configProvider.getConfigurationObject(BrokerCommonConfiguration.NAMESPACE,

--- a/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/BrokerAuthConstants.java
+++ b/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/BrokerAuthConstants.java
@@ -52,8 +52,14 @@ public final class BrokerAuthConstants {
     public static final String SYSTEM_PARAM_USERS_CONFIG = "broker.users.config";
     // users configuration namespace in users config file.
     public static final String USERS_CONFIG_NAMESPACE = "wso2.broker.users";
-    // user manager property name
-    public static final String PROPERTY_USER_STORE_CONNECTOR = "broker.user.store.connector";
     // user manager authorization id
     public static final String AUTHENTICATION_ID = "AuthenticationId";
+
+    /*
+    JaasAuthenitcator related constants.
+     */
+    /**
+     * user registry property name.
+     */
+    public static final String PROPERTY_USER_REGISTRY = "broker.user.registry";
 }

--- a/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/authentication/Authenticator.java
+++ b/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/authentication/Authenticator.java
@@ -19,7 +19,6 @@
 package io.ballerina.messaging.broker.auth.authentication;
 
 import io.ballerina.messaging.broker.auth.AuthException;
-import io.ballerina.messaging.broker.auth.authorization.UserStore;
 import io.ballerina.messaging.broker.common.StartupContext;
 
 import java.util.Map;
@@ -36,11 +35,9 @@ public interface Authenticator {
      * Initiate authenticator with startup context.
      *
      * @param startupContext the startup context provides registered services for authenticator functionality.
-     * @param userStore      {@link UserStore} to get the user information
      * @param properties     set of properties
      */
     void initialize(StartupContext startupContext,
-                    UserStore userStore,
                     Map<String, Object> properties) throws Exception;
 
     /**

--- a/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/authentication/AuthenticatorFactory.java
+++ b/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/authentication/AuthenticatorFactory.java
@@ -19,7 +19,6 @@
 package io.ballerina.messaging.broker.auth.authentication;
 
 import io.ballerina.messaging.broker.auth.BrokerAuthConfiguration;
-import io.ballerina.messaging.broker.auth.authorization.UserStore;
 import io.ballerina.messaging.broker.common.BrokerClassLoader;
 import io.ballerina.messaging.broker.common.StartupContext;
 import org.slf4j.Logger;
@@ -38,20 +37,17 @@ public class AuthenticatorFactory {
      * @param startupContext              the startup context provides registered services for authenticator
      *                                    functionality.
      * @param authenticationConfiguration the authentication configuration
-     * @param userStore                   user store
      * @return authenticator for given configuration
      * @throws Exception throws if error occurred while providing new instance of authenticator
      */
     public Authenticator getAuthenticator(StartupContext startupContext,
                                           BrokerAuthConfiguration.AuthenticationConfiguration
-                                                  authenticationConfiguration,
-                                          UserStore userStore) throws Exception {
+                                                  authenticationConfiguration) throws Exception {
         Authenticator authenticator;
         String authenticatorClass = authenticationConfiguration.getAuthenticator().getClassName();
         LOGGER.info("Initializing authenticator: {}", authenticatorClass);
         authenticator = BrokerClassLoader.loadClass(authenticatorClass, Authenticator.class);
         authenticator.initialize(startupContext,
-                                 userStore,
                                  authenticationConfiguration.getAuthenticator().getProperties());
         return authenticator;
     }

--- a/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/authentication/authenticator/DefaultAuthenticator.java
+++ b/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/authentication/authenticator/DefaultAuthenticator.java
@@ -20,7 +20,6 @@ package io.ballerina.messaging.broker.auth.authentication.authenticator;
 
 import io.ballerina.messaging.broker.auth.authentication.AuthResult;
 import io.ballerina.messaging.broker.auth.authentication.Authenticator;
-import io.ballerina.messaging.broker.auth.authorization.UserStore;
 import io.ballerina.messaging.broker.common.StartupContext;
 
 import java.util.Map;
@@ -32,7 +31,6 @@ public class DefaultAuthenticator implements Authenticator {
 
     @Override
     public void initialize(StartupContext startupContext,
-                           UserStore userStore,
                            Map<String, Object> properties) throws Exception {
         // nothing to do when authentication is disabled.
     }

--- a/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/authentication/authenticator/JaasAuthenticator.java
+++ b/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/authentication/authenticator/JaasAuthenticator.java
@@ -22,9 +22,9 @@ import io.ballerina.messaging.broker.auth.AuthException;
 import io.ballerina.messaging.broker.auth.BrokerAuthConstants;
 import io.ballerina.messaging.broker.auth.authentication.AuthResult;
 import io.ballerina.messaging.broker.auth.authentication.Authenticator;
+import io.ballerina.messaging.broker.auth.authentication.jaas.FileBasedJaasLoginModule;
 import io.ballerina.messaging.broker.auth.authentication.jaas.FileBasedUserRegistry;
 import io.ballerina.messaging.broker.auth.authentication.jaas.PlainSaslCallbackHandler;
-import io.ballerina.messaging.broker.auth.authentication.jaas.UserStoreLoginModule;
 import io.ballerina.messaging.broker.common.StartupContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,7 +55,7 @@ public class JaasAuthenticator implements Authenticator {
             Object jaasLoginModule = properties.get(BrokerAuthConstants.CONFIG_PROPERTY_JAAS_LOGIN_MODULE);
             if (Objects.nonNull(jaasLoginModule)) {
                 // Add user registry for default login module
-                if (jaasLoginModule.toString().equals(UserStoreLoginModule.class.getCanonicalName())) {
+                if (jaasLoginModule.toString().equals(FileBasedJaasLoginModule.class.getCanonicalName())) {
                     properties.put(BrokerAuthConstants.PROPERTY_USER_REGISTRY, new FileBasedUserRegistry());
                 }
                 Configuration jaasConfig = createJaasConfig(jaasLoginModule.toString(), properties);

--- a/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/authentication/authenticator/JaasAuthenticator.java
+++ b/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/authentication/authenticator/JaasAuthenticator.java
@@ -22,9 +22,9 @@ import io.ballerina.messaging.broker.auth.AuthException;
 import io.ballerina.messaging.broker.auth.BrokerAuthConstants;
 import io.ballerina.messaging.broker.auth.authentication.AuthResult;
 import io.ballerina.messaging.broker.auth.authentication.Authenticator;
+import io.ballerina.messaging.broker.auth.authentication.jaas.FileBasedUserRegistry;
 import io.ballerina.messaging.broker.auth.authentication.jaas.PlainSaslCallbackHandler;
 import io.ballerina.messaging.broker.auth.authentication.jaas.UserStoreLoginModule;
-import io.ballerina.messaging.broker.auth.authorization.UserStore;
 import io.ballerina.messaging.broker.common.StartupContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,17 +48,15 @@ public class JaasAuthenticator implements Authenticator {
 
     @Override
     public void initialize(StartupContext startupContext,
-                           UserStore userStore,
                            Map<String, Object> properties) throws Exception {
 
         String jaasConfigPath = System.getProperty(BrokerAuthConstants.SYSTEM_PARAM_JAAS_CONFIG);
         if (jaasConfigPath == null || jaasConfigPath.trim().isEmpty()) {
             Object jaasLoginModule = properties.get(BrokerAuthConstants.CONFIG_PROPERTY_JAAS_LOGIN_MODULE);
             if (Objects.nonNull(jaasLoginModule)) {
-                // Add user store for default login module
+                // Add user registry for default login module
                 if (jaasLoginModule.toString().equals(UserStoreLoginModule.class.getCanonicalName())) {
-                    properties.put(BrokerAuthConstants.PROPERTY_USER_STORE_CONNECTOR,
-                                   userStore);
+                    properties.put(BrokerAuthConstants.PROPERTY_USER_REGISTRY, new FileBasedUserRegistry());
                 }
                 Configuration jaasConfig = createJaasConfig(jaasLoginModule.toString(), properties);
                 Configuration.setConfiguration(jaasConfig);

--- a/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/authentication/authenticator/LdapAuthenticator.java
+++ b/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/authentication/authenticator/LdapAuthenticator.java
@@ -22,7 +22,6 @@ import io.ballerina.messaging.broker.auth.AuthException;
 import io.ballerina.messaging.broker.auth.BrokerAuthConfiguration;
 import io.ballerina.messaging.broker.auth.authentication.AuthResult;
 import io.ballerina.messaging.broker.auth.authentication.Authenticator;
-import io.ballerina.messaging.broker.auth.authorization.UserStore;
 import io.ballerina.messaging.broker.auth.ldap.LdapAuthHandler;
 import io.ballerina.messaging.broker.common.StartupContext;
 import io.ballerina.messaging.broker.common.config.BrokerConfigProvider;
@@ -39,7 +38,6 @@ public class LdapAuthenticator implements Authenticator {
 
     @Override
     public void initialize(StartupContext startupContext,
-                           UserStore userStore,
                            Map<String, Object> properties) throws Exception {
 
         BrokerConfigProvider configProvider = startupContext.getService(BrokerConfigProvider.class);

--- a/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/authentication/jaas/FileBasedJaasLoginModule.java
+++ b/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/authentication/jaas/FileBasedJaasLoginModule.java
@@ -38,10 +38,10 @@ import javax.security.auth.spi.LoginModule;
  * Default JaaS login module {@link LoginModule} for Message broker.
  * This will be configured in jaas.conf file.
  * AuthConfig {
- * {@link UserStoreLoginModule} required;
+ * {@link FileBasedJaasLoginModule} required;
  * };
  */
-public class UserStoreLoginModule implements LoginModule {
+public class FileBasedJaasLoginModule implements LoginModule {
 
     private String userName;
     private String authenticationId;

--- a/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/authentication/jaas/FileBasedUserRegistry.java
+++ b/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/authentication/jaas/FileBasedUserRegistry.java
@@ -31,7 +31,7 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * User registry for the UserStoreLoginModule.
+ * User registry for the FileBasedJaasLoginModule.
  */
 public class FileBasedUserRegistry {
 

--- a/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/authentication/jaas/FileBasedUserRegistry.java
+++ b/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/authentication/jaas/FileBasedUserRegistry.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package io.ballerina.messaging.broker.auth.authentication.jaas;
+
+import io.ballerina.messaging.broker.auth.AuthException;
+import io.ballerina.messaging.broker.auth.AuthInitException;
+import io.ballerina.messaging.broker.auth.authentication.AuthResult;
+import io.ballerina.messaging.broker.auth.user.FileBasedUserLoader;
+import io.ballerina.messaging.broker.auth.user.dto.User;
+import org.wso2.carbon.config.ConfigurationException;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * User registry for the UserStoreLoginModule.
+ */
+public class FileBasedUserRegistry {
+
+    private static Map<String, User> users = new ConcurrentHashMap<>();
+
+    public FileBasedUserRegistry() throws AuthInitException {
+        try {
+            users.putAll(FileBasedUserLoader.loadUsers());
+        } catch (ConfigurationException e) {
+            throw new AuthInitException("Error initializing FileBasedUserRegistry", e);
+        }
+    }
+
+    public AuthResult authenticate(String username, char... credentials) throws AuthException {
+        if (Objects.isNull(username)) {
+            throw new AuthException("Username cannot be null.");
+        }
+        User user = users.get(username);
+        if (Objects.isNull(user)) {
+            throw new AuthException("User not found for the given username.");
+        }
+        if (!Arrays.equals(credentials, user.getPassword())) {
+            throw new AuthException("Password did not match with the configured user");
+        }
+        return new AuthResult(true, username);
+    }
+}

--- a/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/authentication/jaas/UserStoreLoginModule.java
+++ b/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/authentication/jaas/UserStoreLoginModule.java
@@ -22,7 +22,6 @@ import com.sun.security.auth.UserPrincipal;
 import io.ballerina.messaging.broker.auth.AuthException;
 import io.ballerina.messaging.broker.auth.BrokerAuthConstants;
 import io.ballerina.messaging.broker.auth.authentication.AuthResult;
-import io.ballerina.messaging.broker.auth.authorization.UserStore;
 
 import java.io.IOException;
 import java.util.Map;
@@ -51,14 +50,14 @@ public class UserStoreLoginModule implements LoginModule {
     private UserPrincipal userPrincipal;
     private Subject subject;
     private CallbackHandler callbackHandler;
-    private UserStore userStore;
+    private FileBasedUserRegistry fileBasedUserRegistry;
 
     @Override
     public void initialize(Subject subject, CallbackHandler callbackHandler, Map<String, ?> sharedState,
                            Map<String, ?> options) {
         this.subject = subject;
         this.callbackHandler = callbackHandler;
-        this.userStore = (UserStore) options.get(BrokerAuthConstants.PROPERTY_USER_STORE_CONNECTOR);
+        this.fileBasedUserRegistry = (FileBasedUserRegistry) options.get(BrokerAuthConstants.PROPERTY_USER_REGISTRY);
     }
 
     @Override
@@ -75,7 +74,7 @@ public class UserStoreLoginModule implements LoginModule {
         }
         userName = userNameCallback.getName();
         password = passwordCallback.getPassword();
-        AuthResult authResult = userStore.authenticate(userName, password);
+        AuthResult authResult = fileBasedUserRegistry.authenticate(userName, password);
         success = authResult.isAuthenticated();
         if (success) {
             authenticationId = authResult.getUserId();

--- a/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/authorization/UserStore.java
+++ b/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/authorization/UserStore.java
@@ -19,7 +19,6 @@
 package io.ballerina.messaging.broker.auth.authorization;
 
 import io.ballerina.messaging.broker.auth.AuthException;
-import io.ballerina.messaging.broker.auth.authentication.AuthResult;
 import io.ballerina.messaging.broker.common.StartupContext;
 
 import java.util.Map;
@@ -46,16 +45,6 @@ public interface UserStore {
      * @throws AuthException throws if error occurs while authorizing user
      */
     Set<String> getUserGroupsList(String userId) throws AuthException;
-
-    /**
-     * Authenticate given user with credentials.
-     *
-     * @param username    userName
-     * @param credentials credentials
-     * @return Authentication result
-     * @throws AuthException Exception throws when authentication failed.
-     */
-    AuthResult authenticate(String username, char... credentials) throws AuthException;
 
     /**
      * Verify given username against underlying user store.

--- a/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/authorization/provider/FileBasedUserStore.java
+++ b/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/authorization/provider/FileBasedUserStore.java
@@ -18,25 +18,12 @@
  */
 package io.ballerina.messaging.broker.auth.authorization.provider;
 
-import io.ballerina.messaging.broker.auth.AuthException;
-import io.ballerina.messaging.broker.auth.BrokerAuthConstants;
-import io.ballerina.messaging.broker.auth.authentication.AuthResult;
 import io.ballerina.messaging.broker.auth.authorization.UserStore;
-import io.ballerina.messaging.broker.auth.user.config.UserConfig;
-import io.ballerina.messaging.broker.auth.user.config.UsersFile;
+import io.ballerina.messaging.broker.auth.user.FileBasedUserLoader;
 import io.ballerina.messaging.broker.auth.user.dto.User;
 import io.ballerina.messaging.broker.common.StartupContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.wso2.carbon.config.ConfigProviderFactory;
-import org.wso2.carbon.config.provider.ConfigProvider;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -47,78 +34,28 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class FileBasedUserStore implements UserStore {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(FileBasedUserStore.class);
-
-    /**
-     * Store the map of userRegistry.
-     */
-    private static Map<String, User> userRegistry = new ConcurrentHashMap<>();
+    private static Map<String, User> users = new ConcurrentHashMap<>();
 
     @Override
     public void initialize(StartupContext startupContext, Map<String, String> properties) throws Exception {
-        Path usersYamlFile;
-        String usersFilePath = System.getProperty(BrokerAuthConstants.SYSTEM_PARAM_USERS_CONFIG);
-        if (usersFilePath == null || usersFilePath.trim().isEmpty()) {
-            // use current path.
-            usersYamlFile = Paths.get("", BrokerAuthConstants.USERS_FILE_NAME).toAbsolutePath();
-        } else {
-            usersYamlFile = Paths.get(usersFilePath).toAbsolutePath();
-        }
-        ConfigProvider configProvider = ConfigProviderFactory.getConfigProvider(usersYamlFile, null);
-        UsersFile usersFile = configProvider
-                .getConfigurationObject(BrokerAuthConstants.USERS_CONFIG_NAMESPACE, UsersFile.class);
-        if (usersFile != null) {
-            List<UserConfig> usersList = usersFile.getUserConfigs();
-            for (UserConfig userConfig : usersList) {
-                if (userConfig != null && userConfig.getUsername() != null) {
-                    userRegistry.put(userConfig.getUsername(), new User(userConfig.getUsername(),
-                                                                        userConfig.getPassword().toCharArray(),
-                                                                        new HashSet<>(userConfig.getRoles())));
-                } else {
-                    LOGGER.error("User or username can not be null");
-                }
-            }
-        }
-    }
 
-    /**
-     * Authenticate given user with credentials.
-     *
-     * @param username    userName
-     * @param credentials Credentials
-     * @return Authentication result
-     * @throws AuthException Exception throws when authentication failed.
-     */
-    @Override
-    public AuthResult authenticate(String username, char... credentials) throws AuthException {
-        User user;
-        if (Objects.isNull(username)) {
-            throw new AuthException("Username cannot be null.");
-        } else if (Objects.isNull(user = userRegistry.get(username))) {
-            throw new AuthException("User not found for the given username.");
-        } else {
-            if (Arrays.equals(credentials, user.getPassword())) {
-                return new AuthResult(true, username);
-            } else {
-                throw new AuthException("Password did not match with the configured user");
-            }
-        }
+        users.putAll(FileBasedUserLoader.loadUsers());
     }
 
     @Override
     public boolean isUserExists(String username) {
-        return Objects.nonNull(userRegistry.get(username));
+        return Objects.nonNull(users.get(username));
     }
 
     /**
-     * Retrieve the list of userRegistry for given username.
+     * Retrieve the set of users for given username.
      *
      * @param userName user name
      * @return List of roles
      */
     @Override
     public Set<String> getUserGroupsList(String userName) {
-        User user = userRegistry.get(userName);
+        User user = users.get(userName);
         if (user != null) {
             return user.getRoles();
         }

--- a/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/authorization/provider/LdapUserStore.java
+++ b/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/authorization/provider/LdapUserStore.java
@@ -20,7 +20,6 @@ package io.ballerina.messaging.broker.auth.authorization.provider;
 
 import io.ballerina.messaging.broker.auth.AuthException;
 import io.ballerina.messaging.broker.auth.BrokerAuthConfiguration;
-import io.ballerina.messaging.broker.auth.authentication.AuthResult;
 import io.ballerina.messaging.broker.auth.authorization.UserStore;
 import io.ballerina.messaging.broker.auth.ldap.LdapAuthHandler;
 import io.ballerina.messaging.broker.common.StartupContext;
@@ -48,11 +47,6 @@ public class LdapUserStore implements UserStore {
                 .getUserStore().getLdap();
 
         ldapAuthHandler = new LdapAuthHandler(ldapConfiguration);
-    }
-
-    @Override
-    public AuthResult authenticate(String username, char... credentials) throws AuthException {
-        throw new AuthException("Not implemented"); //this functionality will be removed from the user store interface
     }
 
     @Override

--- a/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/user/FileBasedUserLoader.java
+++ b/modules/broker-auth/src/main/java/io/ballerina/messaging/broker/auth/user/FileBasedUserLoader.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package io.ballerina.messaging.broker.auth.user;
+
+import io.ballerina.messaging.broker.auth.BrokerAuthConstants;
+import io.ballerina.messaging.broker.auth.user.config.UserConfig;
+import io.ballerina.messaging.broker.auth.user.config.UsersFile;
+import io.ballerina.messaging.broker.auth.user.dto.User;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.carbon.config.ConfigProviderFactory;
+import org.wso2.carbon.config.ConfigurationException;
+import org.wso2.carbon.config.provider.ConfigProvider;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Load users from user config file.
+ */
+public class FileBasedUserLoader {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FileBasedUserLoader.class.getName());
+
+    public static Map<String, User> loadUsers() throws ConfigurationException {
+
+        Map<String, User> users = new HashMap<>();
+        Path usersYamlFile;
+        String usersFilePath = System.getProperty(BrokerAuthConstants.SYSTEM_PARAM_USERS_CONFIG);
+        if (usersFilePath == null || usersFilePath.trim().isEmpty()) {
+            // use current path.
+            usersYamlFile = Paths.get("", BrokerAuthConstants.USERS_FILE_NAME).toAbsolutePath();
+        } else {
+            usersYamlFile = Paths.get(usersFilePath).toAbsolutePath();
+        }
+        ConfigProvider configProvider = ConfigProviderFactory.getConfigProvider(usersYamlFile, null);
+        UsersFile usersFile = configProvider
+                .getConfigurationObject(BrokerAuthConstants.USERS_CONFIG_NAMESPACE, UsersFile.class);
+        if (usersFile != null) {
+            List<UserConfig> usersList = usersFile.getUserConfigs();
+            for (UserConfig userConfig : usersList) {
+                if (userConfig != null && userConfig.getUsername() != null) {
+                    users.put(userConfig.getUsername(), new User(userConfig.getUsername(),
+                                                                 userConfig.getPassword().toCharArray(),
+                                                                 new HashSet<>(userConfig.getRoles())));
+                } else {
+                    LOGGER.error("User or username can not be null");
+                }
+            }
+        }
+        return users;
+    }
+
+}

--- a/modules/integration/src/test/java/io/ballerina/messaging/broker/integration/util/BrokerNode.java
+++ b/modules/integration/src/test/java/io/ballerina/messaging/broker/integration/util/BrokerNode.java
@@ -25,7 +25,7 @@ import io.ballerina.messaging.broker.auth.AuthManager;
 import io.ballerina.messaging.broker.auth.BrokerAuthConfiguration;
 import io.ballerina.messaging.broker.auth.BrokerAuthConstants;
 import io.ballerina.messaging.broker.auth.authentication.authenticator.JaasAuthenticator;
-import io.ballerina.messaging.broker.auth.authentication.jaas.UserStoreLoginModule;
+import io.ballerina.messaging.broker.auth.authentication.jaas.FileBasedJaasLoginModule;
 import io.ballerina.messaging.broker.auth.authorization.provider.DefaultMacHandler;
 import io.ballerina.messaging.broker.auth.authorization.provider.RdbmsDacHandler;
 import io.ballerina.messaging.broker.common.StartupContext;
@@ -129,7 +129,7 @@ public class BrokerNode {
                 new BrokerAuthConfiguration.AuthenticatorConfiguration();
         HashMap<String, Object> properties = new HashMap<>();
         properties.put(BrokerAuthConstants.CONFIG_PROPERTY_JAAS_LOGIN_MODULE,
-                       UserStoreLoginModule.class.getCanonicalName());
+                       FileBasedJaasLoginModule.class.getCanonicalName());
         authenticatorConfiguration.setClassName(JaasAuthenticator.class.getCanonicalName());
         authenticatorConfiguration.setProperties(properties);
         authenticationConfiguration.setAuthenticator(authenticatorConfiguration);

--- a/modules/integration/src/test/java/io/ballerina/messaging/broker/integration/util/TestUtils.java
+++ b/modules/integration/src/test/java/io/ballerina/messaging/broker/integration/util/TestUtils.java
@@ -23,7 +23,7 @@ import io.ballerina.messaging.broker.amqp.AmqpServerConfiguration;
 import io.ballerina.messaging.broker.auth.BrokerAuthConfiguration;
 import io.ballerina.messaging.broker.auth.BrokerAuthConstants;
 import io.ballerina.messaging.broker.auth.authentication.authenticator.JaasAuthenticator;
-import io.ballerina.messaging.broker.auth.authentication.jaas.UserStoreLoginModule;
+import io.ballerina.messaging.broker.auth.authentication.jaas.FileBasedJaasLoginModule;
 import io.ballerina.messaging.broker.common.StartupContext;
 import io.ballerina.messaging.broker.common.config.BrokerCommonConfiguration;
 import io.ballerina.messaging.broker.common.config.BrokerConfigProvider;
@@ -84,7 +84,7 @@ public class TestUtils {
                 new BrokerAuthConfiguration.AuthenticatorConfiguration();
         HashMap<String, Object> properties = new HashMap<>();
         properties.put(BrokerAuthConstants.CONFIG_PROPERTY_JAAS_LOGIN_MODULE,
-                       UserStoreLoginModule.class.getCanonicalName());
+                       FileBasedJaasLoginModule.class.getCanonicalName());
         authenticatorConfiguration.setClassName(JaasAuthenticator.class.getCanonicalName());
         authenticatorConfiguration.setProperties(properties);
         authenticationConfiguration.setAuthenticator(authenticatorConfiguration);

--- a/modules/launcher/src/main/resources/broker.yaml
+++ b/modules/launcher/src/main/resources/broker.yaml
@@ -73,7 +73,7 @@ ballerina.broker.auth:
     className: io.ballerina.messaging.broker.auth.authentication.authenticator.JaasAuthenticator
     # Optional properties
     properties:
-     loginModule: io.ballerina.messaging.broker.auth.authentication.jaas.UserStoreLoginModule
+     loginModule: io.ballerina.messaging.broker.auth.authentication.jaas.FileBasedJaasLoginModule
  # Broker authorization related configurations.
  authorization:
   # Enable the authorization


### PR DESCRIPTION
## Purpose
Because the UserStore implementation is configurable and it is designed
to be used with authorization it should be possible to have a UserStore
which does not provide authentication.

## Approach
For the default implementation of login module for Jaas authentication
a separate file based user registry is used instead of the configurable
UserStore.
