### PR TITLE
Fix : wso2/ballerina-message-broker#444

### DIFF
--- a/modules/broker-cli-client/src/main/java/io/ballerina/messaging/broker/client/http/HttpClient.java
+++ b/modules/broker-cli-client/src/main/java/io/ballerina/messaging/broker/client/http/HttpClient.java
@@ -145,9 +145,8 @@ public class HttpClient {
             return new HttpResponse(responseCode, response.toString());
         } catch (ConnectException e) {
             BrokerClientException exception = new BrokerClientException();
-            exception.addMessage("Error calling broker https services.");
-            exception.addMessage("Please check whether the broker is running or the connectivity to the broker is not"
-                                 + " blocked through a firewall.");
+            exception.addMessage("CLI tool cannot access " + url + ". \nPlease check whether the broker is running or"
+                                 + " the connectivity to the broker is not blocked through a firewall.");
             exception.addMessage(e.getMessage());
             throw exception;
         } catch (IOException e) {

--- a/modules/broker-cli-client/src/main/java/io/ballerina/messaging/broker/client/http/HttpClient.java
+++ b/modules/broker-cli-client/src/main/java/io/ballerina/messaging/broker/client/http/HttpClient.java
@@ -25,6 +25,7 @@ import java.io.BufferedReader;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.net.ConnectException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -142,6 +143,13 @@ public class HttpClient {
             }
 
             return new HttpResponse(responseCode, response.toString());
+        } catch (ConnectException e) {
+            BrokerClientException exception = new BrokerClientException();
+            exception.addMessage("Error calling broker https service.");
+            exception.addMessage("Please check whether the broker is running or the connectivity to the broker is not"
+                                 + " blocked through a firewall.");
+            exception.addMessage(e.getMessage());
+            throw exception;
         } catch (IOException e) {
             BrokerClientException exception = new BrokerClientException();
             exception.addMessage("error calling broker https service");

--- a/modules/broker-cli-client/src/main/java/io/ballerina/messaging/broker/client/http/HttpClient.java
+++ b/modules/broker-cli-client/src/main/java/io/ballerina/messaging/broker/client/http/HttpClient.java
@@ -145,7 +145,7 @@ public class HttpClient {
             return new HttpResponse(responseCode, response.toString());
         } catch (ConnectException e) {
             BrokerClientException exception = new BrokerClientException();
-            exception.addMessage("Error calling broker https service.");
+            exception.addMessage("Error calling broker https services.");
             exception.addMessage("Please check whether the broker is running or the connectivity to the broker is not"
                                  + " blocked through a firewall.");
             exception.addMessage(e.getMessage());


### PR DESCRIPTION
Improve the error message given when CLI commands are executed without starting the broker.

Related issue : https://github.com/wso2/ballerina-message-broker/issues/444

## Purpose

When a user uses the CLI interface without starting the broker, an error message will be written. But it does not give a hint that the broker should be started. In this fix, a hint is added to the error message to remind the user to start the broker.

## Approach

Filter the exceptions (IOException) thrown when there is an error in connecting to the broker from client, and catch the exception (ConnectException) that is thrown when the broker is not started. Then add an understandable error message.